### PR TITLE
Escaping the back slashes to preserve the # prompt when switching to root

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,13 +12,13 @@ class colorprompt::params {
   case $::osfamily {
 
     'RedHat': {
-      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \W]\\$ '
+      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \W]\\\\$ '
       $modify_skel = false
       $modify_root = false
     }
 
     'Debian': {
-      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \w]\\$ '
+      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \w]\\\\$ '
       $modify_skel = true
       $modify_root = true
     }


### PR DESCRIPTION
I noticed that after puppet compiled the PS1 prompt code it wasn't preserving the double backslashes as a literal string.

simply doubled them up and escaped them so that they weren't mistaken as special characters.