### PR TITLE
Fix escaping of PS1

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,13 +12,13 @@ class colorprompt::params {
   case $::osfamily {
 
     'RedHat': {
-      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \W]\\$ '
+      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \W]\\\\\\$ '
       $modify_skel = false
       $modify_root = false
     }
 
     'Debian': {
-      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \w]\\$ '
+      $prompt      = '${env}[${userColor}\u\[\e[0m\]@${serverColor}\h\[\e[0m\] \w]\\\\\\$ '
       $modify_skel = true
       $modify_root = true
     }


### PR DESCRIPTION
When traveling from the puppet manifest to the actual PS1 variable, a
number of (un)escaping cycles happen:
* we want these 2 characters in PS1: '\\$'
* Since PS1 is set as a double quoted string, we need to escape both the
  backslash and the dollar (to prevent variable expansion): "\\\\\\$"
* Puppet adds an additional layer of escaping. It's a single quoted
  string, so only the backslashes need escaping: '\\\\\\\\\\\\$'